### PR TITLE
- Update lab1-e6 configuring instance to one line command

### DIFF
--- a/lab1-kots/lab1-e6-proxy/README.md
+++ b/lab1-kots/lab1-e6-proxy/README.md
@@ -155,11 +155,7 @@ the `kotsadm` deployment.
 As we did in the airgap scenario, we'll open two SSH tunnels to access the admin console and the app.
 
 ```shell
-ssh -vNL 8800:${REPLICATED_APP}-lab1-e6-proxy:8800 ${JUMP_BOX_IP}
-```
-
-```shell
-ssh -vNL 8888:${REPLICATED_APP}-lab1-e6-proxy:8888 ${JUMP_BOX_IP}
+ssh -vNL 8800:${REPLICATED_APP}-lab1-e6-proxy:8800 -L 8888:${REPLICATED_APP}-lab1-e6-proxy:8888 ${JUMP_BOX_IP}
 ```
 
 From here, we can explore a few last things about our environment


### PR DESCRIPTION
Change original two line command: 
```bash
ssh -vNL 8800:${REPLICATED_APP}-lab1-e6-proxy:8800 ${JUMP_BOX_IP}
```

```bash
ssh -vNL 8888:${REPLICATED_APP}-lab1-e6-proxy:8888 ${JUMP_BOX_IP}
```

to one line command:

```bash
ssh -vNL 8800:${REPLICATED_APP}-lab1-e6-proxy:8800 -L 8888:${REPLICATED_APP}-lab1-e6-proxy:8888 ${JUMP_BOX_IP}
```