### PR TITLE
adds options to override GCP project, zone, and ssh username

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-user := ${USER}
+user := $(or ${REPLICATED_GCP_USER},${USER})
 labs_json := "labs_e0.json"
 env_json := ""
 env_csv := ""
@@ -9,6 +9,8 @@ inviter_email := "dexter+training415@replicated.com"
 inviter_password := ""
 invite_rbac_policy_id := ""
 provisioner_json_out := "terraform/provisioner_pairs.json"
+REPLICATED_GCP_PROJECT ?= "smart-proxy-839"
+REPLICATED_GCP_ZONE ?= "us-central1-b"
 
 .PHONY: install
 install:
@@ -31,8 +33,18 @@ apps: install
 .PHONY: instances
 instances:
 	TF_VAR_user=$(user) \
+	TF_VAR_gcp_project=$(REPLICATED_GCP_PROJECT) \
+	TF_VAR_gcp_zone=$(REPLICATED_GCP_ZONE) \
 	TF_VAR_provisioner_pairs_json=$(provisioner_json_out) \
 	$(MAKE) -C terraform apply
+
+.PHONY: tfdestroy
+tfdestroy:
+	TF_VAR_user=$(user) \
+	TF_VAR_gcp_project=$(REPLICATED_GCP_PROJECT) \
+	TF_VAR_gcp_zone=$(REPLICATED_GCP_ZONE) \
+	TF_VAR_provisioner_pairs_json=$(provisioner_json_out) \
+	$(MAKE) -C terraform destroy
 
 outputs:
 	$(MAKE) -C terraform output

--- a/doc/02-single-player.md
+++ b/doc/02-single-player.md
@@ -60,6 +60,10 @@ You should log into your vendor.replicated.com account to briefly review the app
 
 ## 5. Terraform Init
 
+* By default this procedure will deploy instances to the GCP Project `smart-proxy-839` in zone `us-central1-b`. To set an alternate project `export REPLICATED_GCP_PROJECT=...`. To set an alternate zone `export REPLICATED_GCP_ZONE=...`
+* By default this procedure will provision a user account on the GCP instances that matches your currently logged in local user. To override this in cases where your GCP username differs from your workstation, set `export REPLICATED_GCP_USER=...`
+* The terraform provisioners' connection settings leverage ssh-agent. If terraform errors with ssh timeouts, consider adding your local private key to ssh agent with `ssh-add -K ...`.
+
 If you haven't already, initialize the terraform dir. You can cd in and run `terraform init`, or there's a `make` wrapper for this.
 
 ```shell
@@ -109,7 +113,7 @@ The exception is releases -- new releases for app YAML and kURL installer will a
 ## 10. Cleaning up
 
 ```shell
-make -C terraform destroy
+make tfdestroy
 make apps \
   action=destroy \
   prefix=dh-test \

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,17 @@
+variable "gcp_project" {
+  description = "gcp project to provision instances to"
+}
+variable "gcp_zone" {
+  description = "gcp zone to provision instances to"
+}
+
 provider "google" {
-  project = "smart-proxy-839"
-  region  = "us-central1"
+  project = var.gcp_project
+  region  = join("-",[
+      split("-", var.gcp_zone)[0],
+      split("-", var.gcp_zone)[1],
+    ]
+  )
 }
 
 variable "user" {
@@ -55,7 +66,7 @@ locals {
 
 resource "google_compute_instance" "shared_squid_proxy" {
   name         = "kots-field-labs-squid-proxy"
-  zone         = "us-central1-b"
+  zone         = var.gcp_zone
   machine_type = "n1-standard-1"
 
   boot_disk {
@@ -90,7 +101,7 @@ resource "google_compute_instance" "shared_squid_proxy" {
 resource "google_compute_instance" "airgapped-instance" {
   for_each     = local.airgap_instances
   name         = each.key
-  zone         = "us-central1-b"
+  zone         = var.gcp_zone
   machine_type = each.value.instance.machine_type
 
   provisioner "file" {
@@ -131,7 +142,7 @@ resource "google_compute_instance" "airgapped-instance" {
 resource "google_compute_instance" "kots-field-labs" {
   for_each     = local.regular_instances
   name         = each.key
-  zone         = "us-central1-b"
+  zone         = var.gcp_zone
   machine_type = each.value.machine_type
 
   provisioner "file" {


### PR DESCRIPTION
* Adds optional `REPLICATED_GCP_USER` environment variable, allowing you to override the ssh username used by terraform. Useful when your GCP username and local username aren't the same. No change to existing behavior if omitted.
* Adds optional `REPLICATED_GCP_PROJECT` environment variable, allowing you to override the GCP project. No change to existing behavior if omitted.
* Adds optional `REPLICATED_GCP_ZONE` environment variable, allow you to override the GCP zone. No change to existing behavior if omitted.
* Added `make tfdestroy` needed for destroying the environment if the new options are used. `make -C terraform destroy` no longer worked as documented.
* Updated documentation to reflect these changes and a tip for adding your ssh key to ssh-agent.