### PR TITLE
- Add IAM to kots-field-lab instances

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,6 @@
+data "google_service_account" "default" {
+  account_id = "kots-field-labs"
+}
 variable "gcp_project" {
   description = "gcp project to provision instances to"
 }
@@ -191,6 +194,11 @@ resource "google_compute_instance" "kots-field-labs" {
   network_interface {
     network = "default"
     access_config {}
+  }
+
+  service_account {
+    email  = data.google_service_account.default.email
+    scopes = ["compute-rw", "storage-rw"]
   }
 }
 


### PR DESCRIPTION
Add IAM service account to kots-field-labs instances. This will allow internal Read-Only access to GCS kURL installer.