### PR TITLE
Update README.md

### DIFF
--- a/labs/lab09-licenses/README.md
+++ b/labs/lab09-licenses/README.md
@@ -237,6 +237,7 @@ Create a new manifest with the following contents:
 
 ```yaml
 
+apiVersion: kots.io/v1beta1
 kind: Config
 metadata:
   name: license-app-config


### PR DESCRIPTION
The config manifest is missing "apiVersion: kots.io/v1beta1" at the start