### PR TITLE
Adds a template for a shell + cluster lab

### DIFF
--- a/instruqt/shell-and-cluster-template/01-validate-connectivity/assignment.md
+++ b/instruqt/shell-and-cluster-template/01-validate-connectivity/assignment.md
@@ -1,0 +1,26 @@
+---
+slug: validate-connectivity
+id: 7fzzoeggshcm
+type: challenge
+title: validate-connectivity
+teaser: Validates connectivity between the shell and the cluster
+notes:
+- type: text
+  contents: Let's check that we can connect
+tabs:
+- title: Shell
+  type: terminal
+  hostname: shell
+  workdir: /home/replicant
+- title: Cluster
+  type: terminal
+  hostname: cluster
+difficulty: basic
+timelimit: 3000
+---
+
+#### Let's check our connectivity
+
+```
+kubectl get nodes
+```

--- a/instruqt/shell-and-cluster-template/01-validate-connectivity/check-shell
+++ b/instruqt/shell-and-cluster-template/01-validate-connectivity/check-shell
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# This script runs when the platform check the challenge.
+#
+# The platform determines if the script was successful using the exit code of this
+# script. If the exit code is not 0, the script fails. 
+#
+
+kubectl get nodes 

--- a/instruqt/shell-and-cluster-template/config.yml
+++ b/instruqt/shell-and-cluster-template/config.yml
@@ -1,0 +1,11 @@
+version: "3"
+containers:
+- name: shell
+  image: gcr.io/kots-field-labs/replicated-cli
+  shell: su - replicant
+  memory: 256
+virtualmachines:
+- name: cluster
+  image: instruqt/k3s-v1-25-0
+  shell: /bin/bash
+  machine_type: n1-standard-1

--- a/instruqt/shell-and-cluster-template/track.yml
+++ b/instruqt/shell-and-cluster-template/track.yml
@@ -1,0 +1,22 @@
+slug: shell-and-cluster-template
+id: r0qomiqpceeg
+title: Shell and Cluster Track Template
+teaser: Template track for a shell connecting to a K3s cluster
+description: |-
+  This track is a template track to build any lab that requires
+  a shell that connects to an existing cluster. To use it, run:
+
+  ```
+  instruqt track create --title [NEW TRACK TITLE] \
+    --from shell-and-cluster-template
+  ```
+icon: https://storage.googleapis.com/instruqt-frontend/img/tracks/default.png
+level: beginner
+tags:
+- template
+owner: replicated
+developers:
+- chuck@replicated.com
+private: false
+published: false
+checksum: "14380425741368892975"

--- a/instruqt/shell-and-cluster-template/track_scripts/setup-cluster
+++ b/instruqt/shell-and-cluster-template/track_scripts/setup-cluster
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# This set line ensures that all failures will cause the script to error and exit
+set -euxo pipefail
+
+# simple SSH client setup so we can SSH to/from the shell
+
+cat <<EOF >> "$HOME/.ssh/config"
+Host *
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+    PubkeyAcceptedKeyTypes +ssh-rsa
+EOF
+
+while ! ssh shell true; do
+  echo "Waiting for container SSH to be available..."
+  sleep 1
+done
+
+ssh shell "mkdir /home/replicant/.kube"
+
+while ! [[ -f /etc/rancher/k3s/k3s.yaml ]]; do
+  echo "Waiting for Rancher kubernetes configuration to be available..."
+  sleep 1
+done
+
+scp /etc/rancher/k3s/k3s.yaml shell:/home/replicant/.kube/config

--- a/instruqt/shell-and-cluster-template/track_scripts/setup-shell
+++ b/instruqt/shell-and-cluster-template/track_scripts/setup-shell
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This set line ensures that all failures will cause the script to error and exit
+set -euxo pipefail
+
+# simple SSH client setup so we can SSH to/from the shell
+
+cat <<EOF >> "$HOME/.ssh/config"
+Host *
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+EOF
+
+# assure an RSA key for Dropbear
+ssh-keygen -t rsa -f /etc/dropbear/dropbear_rsa_host_key -N ''
+
+# change the cluster URI
+yq -i '.clusters[0].cluster.server = "https://cluster:6443"' /home/replicant/.kube/config
+chown -R replicant /home/replicant/.kube


### PR DESCRIPTION
TL;DR
-----

Providse a templates track for a shell running independently of the K8s cluster

Details
-------

My first attempts at setting up a lab where the shell for running CLI commands is
independent of the Kubernetes cluster they are run against ran into issues with
the way that the Instruqt bootstrap injects SSH keys and the Dropbear server. This
change captures the pattern I used to workaround the limitations that caused my
earlier lifecycle scripts to fail.

When configurating a track with this setup, the best way to assure access to the
K8s cluster is to take the default config from `/etc/rancher/k3s/k3s.yaml` and
use it from shell host in the sandbox. My first attempts at this ran into two
issues:

1. The timing of `/etc/rancher/k3s/k3s.yaml` being available.  The best way
   around this was to push the file from the cluster host onto the shell host
   so that I could assure the file was in place.
2. A misalignment of SSH key types between the Dropbear server (on the shell
   host) and the SSH client on the cluster host. These are both injected by
   the Instruqt bootstrap. I consider the behavior a bug, but I was able to
   find a workaround.

The workaround gets around the bootstrap issue by assuring that the SSH server
on the shell host has an RSA key to present, then making sure that the SSH client
on the cluster accepts it. Both changes are necessary becuause the bootstrap
was leaving the two in a state where they cluster could not connect to the shell
with it's RSA id and the server only having an ECDSA key.

With this is place, I push the file from the cluster host to the shell host
during track setup, then update it with the correct address when the shell host
sets up. The shell setup also makes sure that the user `replicant` can access
its own Kubernetes config. This step is needed since the edits in the setup
script are run as root.