### PR TITLE
Refers to correct image in Shell/Cluster template

### DIFF
--- a/instruqt/shell-and-cluster-template/config.yml
+++ b/instruqt/shell-and-cluster-template/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 containers:
 - name: shell
-  image: gcr.io/kots-field-labs/replicated-cli
+  image: gcr.io/kots-field-labs/shell
   shell: su - replicant
   memory: 256
 virtualmachines:


### PR DESCRIPTION
TL;DR
-----

Corrects copy/paste error in the Shell/Cluster template

Details
-------

Uses the `gcr.io/kots-field-labs/shell` image in the Shell and
Cluster template rather than the lab specific image for the CLI
lab.
