### PR TITLE
Redactor Lab fix for Challenge #2

### DIFF
--- a/instruqt/redactors/02-redactors-overview/assignment.md
+++ b/instruqt/redactors/02-redactors-overview/assignment.md
@@ -14,6 +14,7 @@ tabs:
 - title: Vendor
   type: website
   url: https://vendor.replicated.com
+  new_window: true
 - title: Application Installer
   type: website
   url: http://kubernetes-vm.${_SANDBOX_ID}.instruqt.io:8800


### PR DESCRIPTION
Vendor Portal was not opening on challenge 2 as I did not have 'new_window:true' set.
This PR adds that line to the **Vendor** section