### PR TITLE
Repairs solve scripts so tests complete

### DIFF
--- a/instruqt/airgap-embedded/01-airgap-overview/solve-jumpbox
+++ b/instruqt/airgap-embedded/01-airgap-overview/solve-jumpbox
@@ -12,6 +12,6 @@ set -euxo pipefail
 #
 
 if ! tmux has-session -t airgap ; then
-  tmux new-session -d -s airgap
+  tmux new-session -d -s airgap su - replicant
 fi
 

--- a/instruqt/airgap-embedded/01-airgap-overview/solve-jumpbox
+++ b/instruqt/airgap-embedded/01-airgap-overview/solve-jumpbox
@@ -3,11 +3,15 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 
-### Deliberately empty solve script to allow skipping this step
+### Assure the tmux session exists
 #
-# The learner can only skip the challange if there's a solve script.
-# I'm putting in a no-op solve script here to allow them to skip this
-# purely informational challenge.
-# 
+# In a test scenario Instuqt does not run the user shell for the
+# challenge, which means the tmux session is never established. We
+# need to session for the solve scripts for other challenges to 
+# succeed, so let's create it here.
+#
 
-exit 0
+if ! tmux has-session -t airgap ; then
+  tmux new-session -d -s airgap
+fi
+

--- a/instruqt/airgap-embedded/02-prepare-your-jumpbox/solve-jumpbox
+++ b/instruqt/airgap-embedded/02-prepare-your-jumpbox/solve-jumpbox
@@ -13,13 +13,17 @@ i=0
 while [[ "$token" == "null" && $i -lt 20 ]]
 do
     sleep 2
+    set +u
     token=$(curl -s -H "Content-Type: application/json" --request POST -d "$login_request" https://id.replicated.com/v1/login | jq -r ".token")
     echo $token
+    set -u
     i=$((i+1))
 done
 
-api_token=$( jq -n -c --arg name "instruqt" --argjson read_only false '$ARGS.named' )
+UUID=$(cat /proc/sys/kernel/random/uuid)
+api_token=$( jq -n -c --arg name "instruqt-${UUID}" --argjson read_only false '$ARGS.named' )
 access_token=$(curl -s -H "Content-Type: application/json" -H "Authorization: $token" --request POST -d "$api_token" https://api.replicated.com/vendor/v1/user/token | jq -r ".access_token")
+app_slug=$(curl -s -H "Content-Type: application/json" -H "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/apps | jq --raw-output ".apps [] | select(.name | test(\".*${INSTRUQT_PARTICIPANT_ID}.*\")).slug")
 
 tmux send-keys -t airgap export SPACE REPLICATED_API_TOKEN=${access_token} ENTER
-tmux send-keys -t airgap export SPACE REPLICATED_APP=$(replicated app ls | grep $INSTRUQT_PARTICIPANT_ID | tr -s ' ' | cut -d ' ' -f3) ENTER
+tmux send-keys -t airgap export SPACE REPLICATED_APP=${app_slug} ENTER

--- a/instruqt/airgap-embedded/03-airgap-deployment-assets/check-jumpbox
+++ b/instruqt/airgap-embedded/03-airgap-deployment-assets/check-jumpbox
@@ -9,5 +9,3 @@ if ! find ${REPLICANT_HOME} -name "installing-in-an-air-gapped-environment-*-uns
   fail-message "You do not appear to have started downloading the bundle, please start the download before continuing"
   exit 1
 fi
-
-exit 0

--- a/instruqt/airgap-embedded/03-airgap-deployment-assets/check-jumpbox
+++ b/instruqt/airgap-embedded/03-airgap-deployment-assets/check-jumpbox
@@ -6,7 +6,7 @@ set -euxo pipefail
 REPLICANT_HOME=/home/replicant
 
 if ! find ${REPLICANT_HOME} -name "installing-in-an-air-gapped-environment-*-unstable.tar.gz" > /dev/null 2>&1 ; then
-  fail-message "Please make sure you've set your API token and run save_lab_setup"
+  fail-message "You do not appear to have started downloading the bundle, please start the download before continuing"
   exit 1
 fi
 

--- a/instruqt/airgap-embedded/03-airgap-deployment-assets/solve-jumpbox
+++ b/instruqt/airgap-embedded/03-airgap-deployment-assets/solve-jumpbox
@@ -3,4 +3,4 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 
-tmux send-keys -t airgap curl SPACE -fSL SPACE -o SPACE uws24vkeurcz-replicated-labs-com-caiman-unstable.tar.gz SPACE https://k8s.kurl.sh/bundle/uws24vkeurcz-replicated-labs-com-caiman-unstable.tar.gz ENTER
+tmux send-keys -t airgap curl SPACE -fSL SPACE -o SPACE installing-in-an-air-gapped-environment-${INSTRUQT_PARTICIPANT_ID}-unstable.tar.gz SPACE https://k8s.kurl.sh/bundle/installing-in-an-air-gapped-environment-${INSTRUQT_PARTICIPANT_ID}-unstable.tar.gz ENTER

--- a/instruqt/airgap-embedded/04-building-an-air-gap-release/assignment.md
+++ b/instruqt/airgap-embedded/04-building-an-air-gap-release/assignment.md
@@ -55,7 +55,7 @@ Let's enable air-gap downloads for the example customer we're using
 for the lab. Go to "Customers" in the Vendor portal and select the
 "Replicant" customer to enable the airgap.
 
-![Enabling Airgap Downloads for a Custtomer](../assets/airgap-customer-enable.png)
+![Enabling Airgap Downloads for a Customer](../assets/airgap-customer-enable.png)
 
 Click the checkbox next to "Airgap Download Enabled" and make sure
 you "Save Changes" with the bottom on the bottom right.

--- a/instruqt/airgap-embedded/04-building-an-air-gap-release/solve-jumpbox
+++ b/instruqt/airgap-embedded/04-building-an-air-gap-release/solve-jumpbox
@@ -3,4 +3,61 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 
-exit 0
+username="${INSTRUQT_PARTICIPANT_ID}@replicated-labs.com"
+password="${INSTRUQT_PARTICIPANT_ID}"
+
+login_request=$( jq -n -c --arg email "${username}" --arg password "${password}" '$ARGS.named' )
+token=$(curl -s -H "Content-Type: application/json" --request POST -d "$login_request" https://id.replicated.com/v1/login | jq -r ".token")
+
+i=0
+while [[ "$token" == "null" && $i -lt 20 ]]
+do
+    sleep 2
+    set +u
+    token=$(curl -s -H "Content-Type: application/json" --request POST -d "$login_request" https://id.replicated.com/v1/login | jq -r ".token")
+    echo $token
+    set -u
+    i=$((i+1))
+done
+
+UUID=$(cat /proc/sys/kernel/random/uuid)
+api_token=$( jq -n -c --arg name "instruqt-${UUID}" --argjson read_only false '$ARGS.named' )
+access_token=$(curl -s -H "Content-Type: application/json" -H "Authorization: $token" --request POST -d "$api_token" https://api.replicated.com/vendor/v1/user/token | jq -r ".access_token")
+app_id=$(curl -s -H "Content-Type: application/json" -H "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/apps | jq --raw-output ".apps [] | select(.name | test(\".*${INSTRUQT_PARTICIPANT_ID}.*\")).id")
+channel_id=$(curl -s -H "Content-Type: application/json" -H "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/app/${app_id}/channels\?channelName\=Unstable | jq -r '.channels[].id')
+
+# enable autobuild airgap for channel "Unstable"
+channel_payload="$(curl -s -H "Content-Type: application/json" -H "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/app/${app_id}/channel/${channel_id} | jq -r '.channel' | jq --arg app_id ${app_id} --arg channel_id ${channel_id} '{
+  "name": .name,
+  "airgapDockerRegistryFormatEnabled": .airgapDockerRegistryFormatEnabled,
+  "autoAirgapBuildsValue": 1,
+  "channelIcon": .channelIcon,
+  "description": .description,
+  "semverRequired": .semverRequired
+}'
+)"
+curl --silent  -H "Content-Type: application/json" -H "Authorization: ${access_token}" --request PUT https://api.replicated.com/vendor/v3/app/${app_id}/channel/${channel_id} --data-raw "${channel_payload}"
+
+# enable airgap for the customer "Replicant"
+customer_id="$(curl -s -H "Content-Type: application/json" -H "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/app/${app_id}/customers | jq -r '.customers[] | select(.name == "Replicant").id')"
+customer_payload="$(curl -s -H "Content-Type: application/json" -H "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/app/${app_id}/customers | jq -r '.customers[] | select(.name == "Replicant")' | jq --arg app_id ${app_id} --arg channel_id ${channel_id} '{ 
+  "app_id": $app_id,
+  "name": .name,
+  "email": .email,
+  "channel_id": $channel_id,
+  "domain": .domain,
+  "avatar": .avatar,
+  "expires_at": .expiresAt,
+  "type": "dev",
+  "is_airgap_enabled": true,
+  "is_gitops_supported": false,
+  "is_identity_service_supported": false,
+  "is_geoaxis_supported": false,
+  "is_snapshot_supported": false,
+  "is_support_bundle_upload_enabled": false,
+  "entitlementValues": []
+}'
+)"
+
+echo "customer_payload=${customer_payload}"
+curl --silent -H "Content-Type: application/json" -H "Authorization: ${access_token}" --request PUT https://api.replicated.com/vendor/v3/customer/${customer_id} --data-raw "${customer_payload}"

--- a/instruqt/airgap-embedded/05-moving-assets-into-place/check-jumpbox
+++ b/instruqt/airgap-embedded/05-moving-assets-into-place/check-jumpbox
@@ -11,4 +11,3 @@ if ! grep -q "installing-in-an-air-gapped-environment" <(echo ${REMOTE_FILES}) ;
   exit 1
 fi
 
-exit 0

--- a/instruqt/airgap-embedded/05-moving-assets-into-place/cleanup-jumpbox
+++ b/instruqt/airgap-embedded/05-moving-assets-into-place/cleanup-jumpbox
@@ -11,4 +11,3 @@ tmux send-keys -t airgap clear ENTER
 # get rid of the tarball
 rm /home/replicant/*-replicated-labs-com.tar.gz
 
-exit 0

--- a/instruqt/airgap-embedded/05-moving-assets-into-place/solve-jumpbox
+++ b/instruqt/airgap-embedded/05-moving-assets-into-place/solve-jumpbox
@@ -3,4 +3,17 @@
 # This set line ensures that all failures will cause the script to error and exit
 set -euxo pipefail
 
-tmux send-keys -t airgap scp SPACE -o SPACE StrictHostKeyChecking=no SPACE '*.tar.gz' SPACE cluster: ENTER
+# save the session
+# tmux capture-pane -t airgap -S -
+# SESSION=$(tmux save-buffer -)
+
+# echo "Checking if bundle download is complete..."
+# while ! echo "${SESSION}" | tail -1 | grep "replicant" ;
+# do
+#   sleep 5
+#   tmux capture-pane -t airgap -S -
+#   SESSION=$(tmux save-buffer -)
+# done
+
+REPLICANT_HOME=/home/replicant
+scp -o StrictHostKeyChecking=no ${REPLICANT_HOME}/'*.tar.gz' cluster:

--- a/instruqt/airgap-embedded/05-moving-assets-into-place/solve-jumpbox
+++ b/instruqt/airgap-embedded/05-moving-assets-into-place/solve-jumpbox
@@ -16,4 +16,4 @@ set -euxo pipefail
 # done
 
 REPLICANT_HOME=/home/replicant
-scp -o StrictHostKeyChecking=no ${REPLICANT_HOME}/'*.tar.gz' cluster:
+scp -o StrictHostKeyChecking=no -i ${REPLICANT_HOME}/.ssh/id_ed25519 ${REPLICANT_HOME}/*.tar.gz replicant@cluster:

--- a/instruqt/airgap-embedded/track.yml
+++ b/instruqt/airgap-embedded/track.yml
@@ -17,4 +17,4 @@ developers:
 - chuck@replicated.com
 private: true
 published: false
-checksum: "3467662508439106007"
+checksum: "5062788266191797849"

--- a/instruqt/airgap-embedded/track.yml
+++ b/instruqt/airgap-embedded/track.yml
@@ -17,4 +17,4 @@ developers:
 - chuck@replicated.com
 private: true
 published: false
-checksum: "12775664847392618721"
+checksum: "3467662508439106007"


### PR DESCRIPTION
TL;DR
-----

Makes the tests pass

Details
-------

Addresses issues with missing `tmux` session cauasing solve scripts
to fail. Getting the session in place made the tests progress, but 
only to another script that failed. Made some additional changes to
make sure they other failures were resolved as well.

Along the way I realized an opporunity to improve the checks for the
"Building an Airgap Bundle" challenge. This meant a bit of messing 
around with the Vendor Portal API to get both check and solve for the
setting the channel and customer up for airgap. Those changes are 
also part of this PR.

To Do
-----

Some challenges still put a test marker in place in their solve 
script, then bypass their checks if the marker is in place. I have
plans for real solve scripts for them.