### PR TITLE
Updates the list of owners to the full SE team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @jdewinne @BarryWilliams
+*   @jdewinne @cremerfc @crdant @grahamnscp 


### PR DESCRIPTION
TL;DR
-----

Brings `CODEOWNERS` up to date

Details
-------

Records the current members of the Replicated SE team as the code owners for the entire repository.