### PR TITLE
Change text to match vendor portal UI

### DIFF
--- a/instruqt/helm-hello-world/02-getting/assignment.md
+++ b/instruqt/helm-hello-world/02-getting/assignment.md
@@ -64,7 +64,7 @@ Note that for some values, the value is not a hard coded value, rather it has so
 
 ## 3. Copy Install Command
 
-Go back to **Channels** and go to the `Stable` channel. On the bottom of the channel card, select to copy the install command for `existing install`
+Go back to **Channels** and go to the `Stable` channel. On the bottom of the channel card, select to copy the install command for `Existing Cluster`
 
 <p align="center"><img src="../assets/install-command.png" width=600></img></p>
 


### PR DESCRIPTION
The text used to say 'existing install' However, the vendor portal UI actually says 'Existing Cluster'