### PR TITLE
Capitalize first word of teaser

### DIFF
--- a/instruqt/support-cli/track.yml
+++ b/instruqt/support-cli/track.yml
@@ -1,7 +1,7 @@
 slug: support-cli
 id: uab72ueg5ox2
 title: Support CLI
-teaser: use the kubectl support-bundle plugin
+teaser: Use the kubectl support-bundle plugin
 description: |-
   In this lab, we'll learn how to debug and diagnose support problems when the KOTS admin console is unavailable.
 


### PR DESCRIPTION
This is the only one that isn't capitalized.
<img width="1201" alt="Screen Shot 2022-11-11 at 4 27 59 PM" src="https://user-images.githubusercontent.com/7272359/201433623-011405d1-2127-48b0-a665-914c266b71d3.png">
