### PR TITLE
Stubs out the lab "Closing the Support Information Gap"

### DIFF
--- a/instruqt/closing-information-gap/01-working-with-support-bundles/assignment.md
+++ b/instruqt/closing-information-gap/01-working-with-support-bundles/assignment.md
@@ -1,0 +1,80 @@
+---
+slug: working-with-support-bundles
+type: challenge
+title: Working with Support Bundkes
+teaser: |-
+  Learn how support bundles help you understand what is going
+  on with a customer instance
+notes:
+- type: text
+  contents: Let's learn about Support Bundles
+tabs:
+- title: Shell
+  type: terminal
+  hostname: shell
+- title: Manifest Editor
+  type: code
+  hostname: shell
+  path: /home/replicant
+difficulty: basic
+timelimit: 300
+---
+
+👋 Introduction
+===============
+
+When your software is running in a customer cluster, you no longer
+have direct access to troubleshoot when things go wrong. You won't
+be able to see what's running, read logs, or even confirm that the
+ever started up. Your cutsomer can do these things, but they may
+need your guidance to do them correctly and coordinating that 
+information sharing can be challenging.
+
+The Replicated Platform let's you define a support bundles that
+your customer can send to you to bring you the visbility you need.
+Support bundles can also surface specific issues and provide 
+guidance to your customer in order to repair issues on their own.
+They are part of the [Troubleshoot](https://troubleshoot.sh) open 
+source project.
+
+What is a Support Bundle?
+=========================
+
+Support Bundles collect the information you need to understand their
+cluster and how your application is running in it. The Replicated 
+Platform allows you to do this without installing anything else
+into the cluster
+
+You define your bundle in a YAML file that follows the same format
+as a Kubernetes object. The simplest support bundle object looks
+like this, and it's in the file `simplest-support-bundle.yaml`:
+
+```
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: simplest-support-bundle
+spec:
+  collectors: []
+  analyzers: []
+```
+
+As the name `empty-` suggests, this is an empty set
+of checks and will not execute. Let's try it out.
+
+```
+kubectl support-bundle ./simplest-support-bundle.yaml
+```
+
+It will take a few seconds to generate a support bundle in a
+file named `support-bundle-$TIMESTAMP.tar.gz` that contains
+some simplest information about the cluster. You can get a
+flavor for what's in the bundle by running
+
+```
+tar -tzf support-bundle-*.tar.gz | less
+```
+
+You'll see the files that were collected cataloging all of the
+resources in the cluster and some information about the cluster
+itself.

--- a/instruqt/closing-information-gap/01-working-with-support-bundles/cleanup-shell
+++ b/instruqt/closing-information-gap/01-working-with-support-bundles/cleanup-shell
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This set line ensures that all failures will cause the script to error and exit
+set -euxo pipefail
+
+# clear the tmux pane and scrollback to look like a fresh shell
+tmux clear-history -t shell 
+tmux send-keys -t shell clear ENTER
+
+exit 0

--- a/instruqt/closing-information-gap/01-working-with-support-bundles/setup-shell
+++ b/instruqt/closing-information-gap/01-working-with-support-bundles/setup-shell
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# This set line ensures that all failures will cause the script to error and exit
+set -euxo pipefail
+
+HOME_DIR=/home/replicant
+
+# Wait for Instruqt bootstrap to be complete
+while [ ! -f /opt/instruqt/bootstrap/host-bootstrap-completed ]
+do
+  echo "Waiting for Instruqt to finish booting the VM"
+  sleep 1
+done
+
+# convenience library for Replicated lab lifecycle scripts
+source /etc/profile.d/header.sh
+
+# there's only one app created by the automation, so just grab the first in the list
+access_token=$(get_api_token)
+app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${access_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].slug')
+
+cat <<EMPTY_SUPPORT_BUNDLE > /home/replicant/simplest-support-bundle.yaml
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: simplest-support-bundle
+spec:
+  collectors: []
+  analyzers: []
+EMPTY_SUPPORT_BUNDLE
+chown replicant /home/replicant/simplest-support-bundle.yaml
+
+agent variable set USERNAME $(get_username)
+agent variable set PASSWORD $(get_password)
+agent variable set REPLICATED_API_TOKEN ${access_token}
+agent variable set REPLICATED_APP ${app_slug}
+
+

--- a/instruqt/closing-information-gap/config.yml
+++ b/instruqt/closing-information-gap/config.yml
@@ -1,0 +1,14 @@
+version: "3"
+containers:
+- name: shell
+  image: gcr.io/kots-field-labs/shell:feature-helm-preflights
+  shell: tmux new-session -A -s shell su - replicant
+virtualmachines:
+- name: cluster
+  image: instruqt/k3s-v1-27-1
+  shell: /bin/bash
+  environment:
+    K3S_TOKEN: cccccbeuretcrjjbrdgvklfgelvelltcftfujlrctlku
+  machine_type: n1-standard-2
+  allow_external_ingress:
+  - high-ports

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -1,0 +1,31 @@
+slug: closing-information-gap
+title: Closing the Support Information Gap
+teaser: |-
+  Use the Replicated Platform to close the information gap between your
+  customers and your support team
+description: |-
+  Learn how to use the Replicated Platform and the [Troubleshoot](https://troubleshoot.sh)
+  open source project to close the information gap between your customers and
+  your supprot team.
+
+   **This lab demonstrates how to:**
+
+   * Review telemetry provided by customer instances to gain insight into their
+     instance of your application
+   * Define a support bundle that gives your team the information they need about
+     a customer's running instance to resolve issue faster
+   * Iterate on your support bundle definition to avoid having to solve the same
+     issue multiple times
+icon: https://storage.googleapis.com/shared-lab-assets/icons/red/audit_log.png
+tags:
+- builders-plan
+- helm
+- troubleshoot
+owner: replicated
+developers:
+- chuck@replicated.com
+maintenance: true
+lab_config:
+  overlay: false
+  width: 33
+  position: right

--- a/instruqt/closing-information-gap/track_scripts/setup-cluster
+++ b/instruqt/closing-information-gap/track_scripts/setup-cluster
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# This set line ensures that all failures will cause the script to error and exit
+set -euxo pipefail
+
+# simple SSH client setup so we can SSH to/from the shell
+
+cat <<EOF >> "$HOME/.ssh/config"
+Host *
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+    PubkeyAcceptedKeyTypes +ssh-rsa
+EOF
+
+while ! ssh shell true; do
+  echo "Waiting for container SSH to be available..."
+  sleep 1
+done
+
+# Wait for the Kubernetes API server to become available
+while ! curl --fail --output /dev/null http://localhost:8001/api 
+do
+    sleep 1 
+done
+
+ssh shell "mkdir /home/replicant/.kube"
+
+while ! [[ -f /etc/rancher/k3s/k3s.yaml ]]; do
+  echo "Waiting for Rancher kubernetes configuration to be available..."
+  sleep 1
+done
+
+scp /etc/rancher/k3s/k3s.yaml shell:/home/replicant/.kube/config

--- a/instruqt/closing-information-gap/track_scripts/setup-shell
+++ b/instruqt/closing-information-gap/track_scripts/setup-shell
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+# This set line ensures that all failures will cause the script to error and exit
+set -euxo pipefail
+
+# simple SSH client setup so we can SSH to/from the shell
+
+cat <<EOF >> "$HOME/.ssh/config"
+Host *
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+EOF
+
+# assure an RSA key for Dropbear
+ssh-keygen -t rsa -f /etc/dropbear/dropbear_rsa_host_key -N ''
+
+# use our shared libary in setup scripts
+curl -s -o /etc/profile.d/header.sh https://raw.githubusercontent.com/replicatedhq/kots-field-labs/feature-helm-preflights/libs/header.sh
+source /etc/profile.d/header.sh
+
+# change the cluster URI
+yq -i '.clusters[0].cluster.server = "https://cluster:6443"' /home/replicant/.kube/config
+chown -R replicant /home/replicant/.kube
+
+# setup for Vendor Portal access
+# there's only one app created by the automation, so just grab the first in the list
+api_token=$(get_api_token)
+app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].slug')
+export REPLICATED_API_TOKEN=${api_token}
+export REPLICATED_APP=${app_slug}
+
+cd /home/replicant
+mkdir release
+helm pull oci://registry-1.docker.io/bitnamicharts/harbor --untar
+yq -i '.version = "16.7.0"' harbor/Chart.yaml
+yq -i '.dependencies += { "name": "replicated", "repository": "oci://registry.replicated.com/library", "version": "0.0.1-alpha.16"}' harbor/Chart.yaml
+
+# update dependencies
+helm dependency update harbor
+
+# re-package the chart
+helm package harbor --destination release
+
+# release and promote the app with the SDK added
+
+# release to the `Unstable` channel
+replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 16.7.0 \
+  --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
+  --app ${app_slug} --token ${api_token}
+
+# get the sequence number for the release to promote
+release_sequence=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .releaseSequence')
+
+# promote to the `Beta` channel
+replicated release promote ${release_sequence} Beta --version 16.7.0 \
+  --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
+  --app ${app_slug} --token ${api_token}
+ 
+# promote to the `Stable` channel
+replicated release promote ${release_sequence} Stable --version 16.7.0 \
+  --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK" \
+  --app ${app_slug} --token ${api_token}
+
+# create LTS channel from the "distributing" lab so things look consistent
+replicated channel create --name LTS --description "Releases with long-term support available" \
+  --app ${app_slug} --token ${api_token}
+
+# remove the helm chart we used to create the release
+rm /home/replicant/release/harbor-16.7.0.tgz
+
+# add preflight checks to the Helm chart
+cat <<HARBOR_PREFLIGHTS > /home/replicant/harbor/templates/preflights.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}-preflight
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: preflight
+    troubleshoot.sh/kind: preflight
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  preflight.yaml: | 
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Preflight
+    metadata:
+      name: harbor-preflight-checks
+    spec:
+      analyzers:
+        - clusterVersion:
+            outcomes:
+              - fail:
+                  when: "< 1.19.x"
+                  message: |-
+                    Your Kubernets cluster is running a version of Kubernetes that is not supported by the Harbor container
+                    registry and your installation will not succeed. Please upgrade your cluster or install to a different
+                    cluster running at least Kubernetes 1.19, ideally version 1.24.0 or later.
+                  uri: https://github.com/bitnami/charts/blob/main/bitnami/harbor/README.md
+              - warn:
+                  when: "< 1.24.0"
+                  message: |-
+                    Your Kubernetes cluster is running a version of Kubernetes that is not longer supported by the Kubernetes
+                    community. If you are receiving extended support from your Kubernetes provider you may be able to ignore
+                    this warning. If not, we recomend that you upgrade your cluster to at least version 1.24.0.
+                  uri: https://kubernetes.io
+              - pass:
+                  message: Your cluster is running a version of Kubernetes that is supported by the Harbor container registry.
+        - nodeResources:
+            checkName: Cluster CPU resources are sufficient to install and run Harbor
+            outcomes:
+              - fail:
+                  when: "sum(cpuAllocatable) < 2"
+                  message: |-
+                    Harbor requires a minimum of 2 CPU cores in order to run, and runs best with
+                    at least 4 cores. Your current cluster has less than 2 CPU cores available to Kubernetes
+                    workloads. Please increase cluster capacity or install into a different cluster.
+                  uri: https://goharbor.io/docs/2.8.0/install-config/installation-prereqs/
+              - warn:
+                  when: "sum(cpuAllocatable) < 4"
+                  message: |-
+                    Harbor runs best with a minimum of 4 CPU cores. Your current cluster has less
+                    than 4 CPU cores available to run workloads. For the best experience, consider
+                    increasing cluster capacity or installing into a different cluster.
+                  uri: https://goharbor.io/docs/2.8.0/install-config/installation-prereqs/
+              - pass:
+                  message: Your cluster has sufficient CPU resources available to run Harbor
+        - nodeResources:
+            checkName: Cluster memory is sufficient to install and run Harbor
+            outcomes:
+              - fail:
+                  when: "sum(memoryAllocatable) < 4G"
+                  message: |-
+                    Harbor requires a minimum of 4 GB of memory in order to run, and runs best with
+                    at least 8 GB. Your current cluster has less than 4 GB available to Kubernetes
+                    workloads. Please increase cluster capacity or install into a different cluster.
+                  uri: https://goharbor.io/docs/2.8.0/install-config/installation-prereqs/
+              - warn:
+                  when: "sum(memoryAllocatable) < 8Gi"
+                  message: |-
+                    Harbor runs best with a minimum of 8 GB of memory. Your current cluster has less
+                    than 8 GB of memory available to run workloads. For the best experience, consider
+                    increasing cluster capacity or installing into a different cluster.
+                  uri: https://goharbor.io/docs/2.8.0/install-config/installation-prereqs/
+              - pass:
+                  message: Your cluster has sufficient memory available to run Harbor
+HARBOR_PREFLIGHTS
+
+# bump the version
+yq -i '.version = "16.8.0"' /home/replicant/harbor/Chart.yaml
+helm package /home/replicant/harbor --destination /home/replicant/release
+chown -R replicant /home/replicant/harbor /home/replicant/release
+#
+# release and promote the preflight checks added
+
+# release to the `Unstable` channel
+replicated release create --promote Unstable --yaml-dir /home/replicant/release --version 16.8.0 \
+  --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
+  --app ${app_slug} --token ${api_token}
+
+# get the sequence number for the release to promote
+release_sequence=$(curl --header "Accept: application/json" --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].channels[] | select( .name == "Unstable" ) | .releaseSequence')
+
+# promote to the `Beta` channel
+replicated release promote ${release_sequence} Beta --version 16.8.0 \
+  --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
+  --app ${app_slug} --token ${api_token}
+ 
+# promote to the `Stable` channel
+replicated release promote ${release_sequence} Stable --version 16.8.0 \
+  --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing" \
+  --app ${app_slug} --token ${api_token}
+
+# create LTS channel from the "distributing" lab so things look consistent
+replicated channel create --name LTS --description "Releases with long-term support available" \
+  --app ${app_slug} --token ${api_token}
+
+# remove the helm chart we used to create the release
+rm /home/replicant/release/harbor-16.8.0.tgz
+
+# make sure permissions are good
+chown -R replicant /home/replicant/harbor /home/replicant/release

--- a/instruqt/closing-information-gap/vendor/vendor.json
+++ b/instruqt/closing-information-gap/vendor/vendor.json
@@ -1,0 +1,7 @@
+{
+    "name": "Harbor",
+    "slug": "harbor",
+    "customer": "Omozan",
+    "yaml_dir": "",
+    "k8s_installer_yaml_path": ""
+}


### PR DESCRIPTION
TL;DR
-----

Creates a skeleton for a Builders Plan support lab to speed iteration

Details
-------

Starts a new Builders Plan support lab implementation so that the
files needed to the Instruqt -> Vendor Portal automation to work can
be on `main` early in the development process. This enables faster
iteration by avoiding the need to pass in the `icp_branch` parameter
and enter the lab at certain URLs.
