### PR TITLE
Updates for Harbor and SDK version bumps

### DIFF
--- a/instruqt/avoiding-installation-pitfalls/track_scripts/setup-shell
+++ b/instruqt/avoiding-installation-pitfalls/track_scripts/setup-shell
@@ -31,9 +31,9 @@ export REPLICATED_APP=${app_slug}
 
 cd /home/replicant
 mkdir release
-helm pull oci://registry-1.docker.io/bitnamicharts/harbor --untar
+helm pull --version 16.6.8 oci://registry-1.docker.io/bitnamicharts/harbor --untar
 yq -i '.version = "16.7.0"' harbor/Chart.yaml
-yq -i '.dependencies += { "name": "replicated", "repository": "oci://registry.replicated.com/library", "version": "0.0.1-alpha.16"}' harbor/Chart.yaml
+yq -i '.dependencies += { "name": "replicated", "repository": "oci://registry.replicated.com/library", "version": "0.0.1-alpha.17"}' harbor/Chart.yaml
 
 # update dependencies
 helm dependency update harbor

--- a/instruqt/closing-information-gap/track_scripts/setup-shell
+++ b/instruqt/closing-information-gap/track_scripts/setup-shell
@@ -34,9 +34,9 @@ export REPLICATED_APP=${app_slug}
 ## release the application with the Replicated SDK
 cd /home/replicant
 mkdir release
-helm pull oci://registry-1.docker.io/bitnamicharts/harbor --untar
+helm pull --version 16.6.8 oci://registry-1.docker.io/bitnamicharts/harbor --untar
 yq -i '.version = "16.7.0"' harbor/Chart.yaml
-yq -i '.dependencies += { "name": "replicated", "repository": "oci://registry.replicated.com/library", "version": "0.0.1-alpha.16"}' harbor/Chart.yaml
+yq -i '.dependencies += { "name": "replicated", "repository": "oci://registry.replicated.com/library", "version": "0.0.1-alpha.17"}' harbor/Chart.yaml
 
 # update dependencies
 helm dependency update harbor

--- a/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
@@ -2,7 +2,7 @@
 slug: preparing-to-use-the-sdk
 id: kkhcf1j4eaym
 type: challenge
-title: Preparing to use the SDK
+title: Preparing to Use the SDK
 teaser: Getting ready to use the Replicated SDK
 notes:
 - type: text
@@ -36,14 +36,15 @@ things. They've been set up for you in this lab environment.
 1. A Helm chart for your application. We're going to use the
    Open Source Bitnami Helm chart for the Harbor container registry
    for this lab, but it could be the Helm chart for your product
-   or any other Helm chart you want to distribute this way.
+   or any other Helm chart you wanted to distribute this way.
 2. Access to the Replicated Vendor Portal. You've been given
    access for the duration of this lab with the username
    `[[ Instruqt-Var key="USERNAME" hostname="shell" ]]` and
    the password `[[ Instruqt-Var key="PASSWORD" hostname="shell" ]]`
-3. An application on the Replicated Vendor Portal. This was
+3. An application on the Replicated Vendor Portal. It was also
    created for you as part of the lab setup.
-4. A customer for that application. This was created for you as part of the lab setup as well.
+4. A customer for that application. The automation created the
+   customer as well.
 
 🔤 Getting Started
 ==================
@@ -57,14 +58,14 @@ helm pull oci://registry-1.docker.io/bitnamicharts/harbor --untar
 ```
 
 Let's also set up our shell for interacting with the Replicated
-Platform.
+platform.
 
 ```
 export REPLICATED_API_TOKEN="[[ Instruqt-Var key="REPLICATED_API_TOKEN" hostname="shell" ]]"
 ```
 
-And lastly, let's make sure we are working with the Harbor app that was
-created during the lab setup.
+And lastly make sure we are working with the Harbor app that was
+created by the lab setup.
 
 ```
 export REPLICATED_APP="[[ Instruqt-Var key="REPLICATED_APP" hostname="shell" ]]"

--- a/instruqt/distributing-with-replicated/02-enabling-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/02-enabling-the-sdk/assignment.md
@@ -31,9 +31,9 @@ This injection serves a few purposes:
 1. The license is available to your application logic through a
    call to an API provided by an in-cluster service.
 2. Access to your container images and other registry
-   assets is secured using customer-specific credentials.
+   assets is secured using customer-specific credentials
 3. The in-cluster service can connect securely to the Replicated
-   Vendor Portal for telemetry, upgrade checks, etc.
+   vendor portal for telemetry, upgrade checks, etc.
 
 Adding the Dependency
 ======================
@@ -42,13 +42,13 @@ Go to the the "Manifest Editor" tab and edit the file `Chart.yaml` in
 the source directory `harbor`. You're going to make two changes to
 this file.
 
-First, you're going to add a dependency to the Replicated SDK Helm
+First, you're going to add a dependency on the Replicated SDK Helm
 chart.
 
 ```
 - name: replicated
   repository: oci://registry.replicated.com/library
-  version: 0.0.1-alpha.15
+  version: 0.0.1-alpha.17
 ```
 
 You should put the dependency into the array with the other

--- a/instruqt/distributing-with-replicated/02-enabling-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/02-enabling-the-sdk/assignment.md
@@ -48,7 +48,7 @@ chart.
 ```
 - name: replicated
   repository: oci://registry.replicated.com/library
-  version: 0.0.1-alpha.17
+  version: 0.0.1-alpha.21
 ```
 
 You should put the dependency into the array with the other

--- a/instruqt/distributing-with-replicated/02-enabling-the-sdk/solve-shell
+++ b/instruqt/distributing-with-replicated/02-enabling-the-sdk/solve-shell
@@ -19,7 +19,7 @@ fi
 tmux send-keys -t shell $'yq -i \'.version = "16.7.0"\' harbor/Chart.yaml' ENTER
 
 # add the SDK dependency
-tmux send-keys -t shell $'yq -i \'.dependencies += { "name": "replicated", "repository": "oci://registry.replicated.com/library", "version": "0.0.1-alpha.15"}\' harbor/Chart.yaml' ENTER
+tmux send-keys -t shell $'yq -i \'.dependencies += { "name": "replicated", "repository": "oci://registry.replicated.com/library", "version": "0.0.1-alpha.21"}\' harbor/Chart.yaml' ENTER
 
 # update dependencies
 tmux send-keys -t shell 'helm dependency update harbor'  ENTER

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -24,4 +24,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "18024878191063829088"
+checksum: "9254975006048077381"

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -24,4 +24,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "1484816796465641413"
+checksum: "18024878191063829088"


### PR DESCRIPTION
TL;DR
-----

Pins Harbor version, updates Replicated SDK


Details
-------

Makes two changes related to versioning:

* Updates the version of the Replicated SDK in the to alpha 17
* "Pins" the Harbor version by downloading a specific version of the chart, so
  that all of the version bumps in the labs make sense

