### PR TITLE
Enables labs to run with a Builders Plan only team

### DIFF
--- a/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/setup-shell
+++ b/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/setup-shell
@@ -19,12 +19,6 @@ curl --location "https://api.replicated.com/vendor/v3/customer/${omozan_customer
   --request PUT --header 'Accept: application/json' --header "Authorization: ${api_token}" \
   --header "Content-Type: application/json" \
   --data "${updated_existing_customer}"
- 
-# toggle the app to builders mode 
-curl  --location "https://api.replicated.com/vendor/v3/app/${app_id}" \
-  --request POST --header 'Accept: application/json' --header "Authorization: ${api_token}" \
-  --header "Content-Type: application/json" \
-  --data '{ "is_foundation": true }'
 
 # email for the customer the user will create
 new_customer_email=${INSTRUQT_PARTICIPANT_ID}@geeglo.io

--- a/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/setup-shell
+++ b/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/setup-shell
@@ -8,14 +8,14 @@ source /etc/profile.d/header.sh
 # and users like to copy/paste
 api_token=$(get_api_token)
 app_id=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" https://api.replicated.com/vendor/v3/apps | jq -r '.apps[0].id')
-omozon_customer_id=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customers" | jq -r '.customers[0].id')
+omozan_customer_id=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customers" | jq -r '.customers[0].id')
 
 # set the customer email so the user doesn't have to do it, also make it a paid license for the optics
 existing_email="${INSTRUQT_PARTICIPANT_ID}@omozan.io"
-updated_existing_customer=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${omozon_customer_id}" | \
+updated_existing_customer=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${omozan_customer_id}" | \
   jq -c --arg appId "${app_id}" --arg email "${existing_email}" '.customer | {"app_id": $appId, "name": .name, "email": $email, "channel_id": .channels[0].id, "expires_at": .expiresAt, "type": "prod", "is_airgap_enabled": .airgap, "is_gitops_supported": .isGitopsSupported, "is_identity_service_supported": .isIdentityServiceSupported, "is_geoaxis_supported": .isGeoaxisSupported, "is_snapshot_supported": .isSnapshotSupported, "is_support_bundle_upload_enabled": .isSupportBundleUploadEnabled, "entitlementValues":[]}')
 
-curl --location "https://api.replicated.com/vendor/v3/customer/${customer_id}" \
+curl --location "https://api.replicated.com/vendor/v3/customer/${omozan_customer_id}" \
   --request PUT --header 'Accept: application/json' --header "Authorization: ${api_token}" \
   --header "Content-Type: application/json" \
   --data "${updated_existing_customer}"
@@ -32,6 +32,6 @@ new_customer_email=${INSTRUQT_PARTICIPANT_ID}@geeglo.io
 license_expiry=$(date -d "+30 days" "+%B %d, %Y")
 
 agent variable set APP_ID ${app_id}
-agent variable set CUSTOMER_ID ${customer_id}
+agent variable set CUSTOMER_ID ${omozan_customer_id}
 agent variable set LICENSE_EXPIRY "${license_expiry}"
 agent variable set CUSTOMER_EMAIL "${new_customer_email}"

--- a/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/solve-shell
+++ b/instruqt/avoiding-installation-pitfalls/05-validating-before-an-install/solve-shell
@@ -26,8 +26,8 @@ updated_customer=$(curl --header 'Accept: application/json' --header "Authorizat
 # the `replicant` user
 
 # get the registry password (which is the license id)
-registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}/license-download" | \
-  yq .spec.licenseID) 
+registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \
+  yq .customer.installationId) 
 
 ### Assure the tmux session exists
 #

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -29,4 +29,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "7699580194730823768"
+checksum: "6922078494371228"

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -29,4 +29,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "6922078494371228"
+checksum: "9810932458735620670"

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -29,4 +29,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "9810932458735620670"
+checksum: "6797294594329278640"

--- a/instruqt/closing-information-gap/01-viewing-instance-info/assignment.md
+++ b/instruqt/closing-information-gap/01-viewing-instance-info/assignment.md
@@ -62,7 +62,7 @@ lab.
 ![Vendor Portal Landing Page with Release Channels](../assets/vendor-portal-landing.png)
 
 Select the "Customers" link from the left navigation to go see a list of
-customers. 
+customers.
 
 ![Customers Landing Page with Geeglo Showing an Unavailable Instance](../assets/customers-page.png)
 

--- a/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
+++ b/instruqt/closing-information-gap/06-support-bundle-diagnosis/setup-shell
@@ -24,8 +24,8 @@ api_token=$(get_api_token)
 customer_email="${INSTRUQT_PARTICIPANT_ID}@geeglo.io"
 
 # get the registry password (which is the license id)
-registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}/license-download" | \
-  yq .spec.licenseID)
+registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \
+  yq .customer.installationId) 
 
 agent variable set CUSTOMER_EMAIL ${customer_email}
 agent variable set REGISTRY_PASSWORD ${registry_pasword}

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -29,4 +29,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "6919267823612132499"
+checksum: "10403627275154237635"

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -29,4 +29,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "10403627275154237635"
+checksum: "18127403098525702637"

--- a/instruqt/closing-information-gap/track_scripts/setup-shell
+++ b/instruqt/closing-information-gap/track_scripts/setup-shell
@@ -31,12 +31,6 @@ app_slug=$(curl --header 'Accept: application/json' --header "Authorization: ${a
 export REPLICATED_API_TOKEN=${api_token}
 export REPLICATED_APP=${app_slug}
 
-## convert the application to the builders  experience
-curl  --location "https://api.replicated.com/vendor/v3/app/${app_id}" \
-  --request POST --header 'Accept: application/json' --header "Authorization: ${api_token}" \
-  --header "Content-Type: application/json" \
-  --data '{ "is_foundation": true }'
-
 ## release the application with the Replicated SDK
 cd /home/replicant
 mkdir release

--- a/instruqt/closing-information-gap/track_scripts/setup-shell
+++ b/instruqt/closing-information-gap/track_scripts/setup-shell
@@ -208,8 +208,8 @@ updated_customer=$(curl --header 'Accept: application/json' --header "Authorizat
 # the `replicant` user
 
 # get the registry password (which is the license id)
-registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}/license-download" | \
-  yq .spec.licenseID)
+registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \
+  yq .customer.installationId) 
  
 ## install the release so we have something to support
 

--- a/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
+++ b/instruqt/distributing-with-replicated/01-preparing-to-use-the-sdk/assignment.md
@@ -23,7 +23,7 @@ alongside your application and enables access to the Replicated
 Platform. The SDK allows you to enforce your entitlements and
 take advantage of the telemetry that Replicated provides to help
 you better understand customer instances. It also allows you
-to get information about your application and its releases, 
+to get information about your application and its releases,
 including checking for updates and showing version history.
 
 

--- a/instruqt/distributing-with-replicated/04-installing-the-application/setup-shell
+++ b/instruqt/distributing-with-replicated/04-installing-the-application/setup-shell
@@ -21,8 +21,8 @@ curl --location "https://api.replicated.com/vendor/v3/customer/${customer_id}" \
   --data "${updated_customer}"
  
 # get the registry password (which is the license id)
-registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}/license-download" | \
-  yq .spec.licenseID) 
+registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \
+  yq .customer.installationId) 
 
 # toggle the app to builders mode 
 curl  --location "https://api.replicated.com/vendor/v3/app/${app_id}" \

--- a/instruqt/distributing-with-replicated/04-installing-the-application/setup-shell
+++ b/instruqt/distributing-with-replicated/04-installing-the-application/setup-shell
@@ -24,12 +24,6 @@ curl --location "https://api.replicated.com/vendor/v3/customer/${customer_id}" \
 registry_password=$(curl --header 'Accept: application/json' --header "Authorization: ${api_token}" "https://api.replicated.com/vendor/v3/app/${app_id}/customer/${customer_id}" | \
   yq .customer.installationId) 
 
-# toggle the app to builders mode 
-curl  --location "https://api.replicated.com/vendor/v3/app/${app_id}" \
-  --request POST --header 'Accept: application/json' --header "Authorization: ${api_token}" \
-  --header "Content-Type: application/json" \
-  --data '{ "is_foundation": true }'
-
 agent variable set APP_ID ${app_id}
 agent variable set CUSTOMER_ID ${customer_id}
 agent variable set CUSTOMER_EMAIL ${customer_email}

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -24,4 +24,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "6439401780382844245"
+checksum: "12205927217152703458"

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -24,4 +24,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "12205927217152703458"
+checksum: "1484816796465641413"


### PR DESCRIPTION
TL;DR
-----

Updates lab to enable a Builders Plan only team

Details
-------

Converts code that looked at the license to find the regitry password to use
the installation ID from the customer record. This enables us to switch from
using the same team for all labs to using two different teams: one for the
Builders experience and one for the Premium experience. 

The changes to use two different teams is entirely at the Zepier level, so you
won't find it in this codebase.
