### PR TITLE
Update check-shell - fix another typo

### DIFF
--- a/instruqt/closing-information-gap/04-adding-to-the-chart/check-shell
+++ b/instruqt/closing-information-gap/04-adding-to-the-chart/check-shell
@@ -8,7 +8,7 @@ result=0
 # look for the preflight template file
 if [[ ! -f /home/replicant/harbor/templates/troubleshoot/support-bundle.yaml ]] ; then
   fail-message 'Please create the support bundle spec template file in the Harbor Helm chart template directory'
-  let "reasult = result + 1"
+  let "result = result + 1"
 fi
 
 if [[ "$(helm template /home/replicant/harbor | yq 'select( .kind == "Secret" ) | select( .metadata.labels."troubleshoot.sh/kind" == "support-bundle" ) | .stringData | has("support-bundle-spec")')" == "true" ]] ; then


### PR DESCRIPTION
```  
let "reasult = result + 1"
```

assuming this should be `result =` from context