### PR TITLE
Fixes release promotion instructions

### DIFF
--- a/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
+++ b/instruqt/avoiding-installation-pitfalls/04-releasing-the-application/assignment.md
@@ -71,14 +71,13 @@ replicated release ls
 ```
 
 You'll see that the the same release is current across
-all three channels, and it has the sequence number `2`.
+all three channels, and it has the sequence number `1`.
 All releases are assigned a sequence number based on the
 order in which they were created.
 
 ```
 SEQUENCE    CREATED                 EDITED                  ACTIVE_CHANNELS
-2           2023-06-08T00:23:40Z    0001-01-01T00:00:00Z    Stable,Beta,Unstable
-1           2023-06-08T00:19:43Z    0001-01-01T00:00:00Z
+1           2023-06-08T00:23:40Z    0001-01-01T00:00:00Z    Stable,Beta,Unstable
 ```
 
 To release our new version, we create a new release and
@@ -96,12 +95,12 @@ replicated release create --promote Unstable --yaml-dir ./release --version 16.8
 This creates a release for version `16.8.0` of the Harbor Helm
 chart, and promotes it to the `Unstable` channel. The `create`
 command output a sequence number that you'll need for `promote` (it
-will be `3` if you haven't explored releasing a bit more).
+will be `2` if you haven't explored releasing a bit more).
 
 ```
   _ Reading manifests from ./release _
   _ Creating Release _
-    _ SEQUENCE: 3
+    _ SEQUENCE: 2
   _ Promoting _
     _ Channel 2Qa7rGeBiT3DaDK85s6FVKRC7Mn successfully set to release 2
 ```
@@ -113,14 +112,14 @@ of those channels---your teams review and approval processes,
 steps in a continuous delivery pipeline, or both. Run the following command to promote our release to the `Beta` channel:
 
 ```
-replicated release promote 3 Beta --version 16.8.0 \
+replicated release promote 2 Beta --version 16.8.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing"
 ```
 
 Then promote to the `Stable` channel:
 
 ```
-replicated release promote 3 Stable --version 16.8.0 \
+replicated release promote 2 Stable --version 16.8.0 \
   --release-notes "Adds preflight checks to enable customers to validate cluster prerequisites before installing"
 ```
 
@@ -136,7 +135,6 @@ release available on the `Unstable`, `Beta`, and `Unstable` channels.
 
 ```
 SEQUENCE    CREATED                 EDITED                  ACTIVE_CHANNELS
-3           2023-06-10T20:22:14Z    0001-01-01T00:00:00Z    Stable,Beta,Unstable
-2           2023-06-10T20:21:13Z    0001-01-01T00:00:00Z
+2           2023-06-10T20:22:14Z    0001-01-01T00:00:00Z    Stable,Beta,Unstable
 1           2023-06-10T20:20:02Z    0001-01-01T00:00:00Z
 ```

--- a/instruqt/avoiding-installation-pitfalls/track.yml
+++ b/instruqt/avoiding-installation-pitfalls/track.yml
@@ -29,4 +29,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "6797294594329278640"
+checksum: "18363644782998677466"

--- a/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
+++ b/instruqt/closing-information-gap/05-releasing-an-update/assignment.md
@@ -58,12 +58,11 @@ All releases are assigned a sequence number based on the order in which they
 are created. They may also be assigned to zero or more release channels that
 provide specific streams of releases to specific customers. You'll see that the
 the same release is current across all three channels, and it has the sequence
-number `3`
+number `2`
 
 ```
 SEQUENCE    CREATED                 EDITED                  ACTIVE_CHANNELS
-3           2023-06-20T14:52:16Z    0001-01-01T00:00:00Z    Stable,Beta,Unstable
-2           2023-06-20T14:52:08Z    0001-01-01T00:00:00Z
+2           2023-06-20T14:52:16Z    0001-01-01T00:00:00Z    Stable,Beta,Unstable
 1           2023-06-20T14:50:52Z    0001-01-01T00:00:00Z
 ```
 
@@ -79,13 +78,13 @@ replicated release create --promote Unstable --yaml-dir ./release --version 16.9
 
 This creates a release for version `16.9.0` of the Harbor Helm chart, and
 promotes it to the `Unstable` channel. The `create` command output sequence
-number that you'll need for `promote` (it will be `4` if you haven't explored
+number that you'll need for `promote` (it will be `3` if you haven't explored
 releasing a bit more).
 
 ```
   _ Reading manifests from ./release _
   _ Creating Release _
-    _ SEQUENCE: 4
+    _ SEQUENCE: 3
   _ Promoting _
     _ Channel 2Qa7rGeBiT3DaDK85s6FVKRC7Mn successfully set to release 4
 ```
@@ -123,14 +122,14 @@ to determine whether a release should be promoted to each of those
 channels---hopefully automated as part of your continuous delivery pipelines.
 
 ```
-replicated release promote 4 Beta --version 16.9.0 \
+replicated release promote 3 Beta --version 16.9.0 \
   --release-notes "Adds a support bundle spec to facilitate troubleshooting"
 ```
 
 and then
 
 ```
-replicated release promote 4 Stable --version 16.9.0 \
+replicated release promote 3 Stable --version 16.9.0 \
   --release-notes "Adds a support bundle spec to facilitate troubleshooting"
 ```
 
@@ -145,8 +144,7 @@ available on the `Unstable`, `Beta`, and `Unstable` channels.
 
 ```
 SEQUENCE    CREATED                 EDITED                  ACTIVE_CHANNELS
-4           2023-06-20T14:55:32Z    0001-01-01T00:00:00Z    Stable,Beta,Unstable
-3           2023-06-20T14:52:16Z    0001-01-01T00:00:00Z
+3           2023-06-20T14:55:32Z    0001-01-01T00:00:00Z    Stable,Beta,Unstable
 2           2023-06-20T14:52:08Z    0001-01-01T00:00:00Z
 1           2023-06-20T14:50:52Z    0001-01-01T00:00:00Z
 ```

--- a/instruqt/closing-information-gap/track.yml
+++ b/instruqt/closing-information-gap/track.yml
@@ -29,4 +29,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "18127403098525702637"
+checksum: "8657597645467563973"

--- a/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
+++ b/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
@@ -92,12 +92,12 @@ replicated release create --promote Unstable --yaml-dir ./release --version 16.7
 This creates a release for version `16.7.0` of your Harbor Helm
 chart, and promotes it to the `Unstable` channel.  The `create`
 command output a sequence number that you'll need for `promote`
-(it will be `2` if you haven't explored releasing a bit more).
+(it will be `1` if you haven't explored releasing a bit more).
 
 ```
   _ Reading manifests from ./release _
   _ Creating Release _
-    _ SEQUENCE: 2
+    _ SEQUENCE: 1
   _ Promoting _
     _ Channel 2Qa7rGeBiT3DaDK85s6FVKRC7Mn successfully set to release 2
 ```
@@ -117,8 +117,7 @@ if any.
 
 ```
 SEQUENCE    CREATED                 EDITED                  ACTIVE_CHANNELS
-2           2023-06-08T00:23:40Z    0001-01-01T00:00:00Z    Unstable
-1           2023-06-08T00:19:43Z    0001-01-01T00:00:00Z    Stable
+1           2023-06-08T00:23:40Z    0001-01-01T00:00:00Z    Unstable
 ```
 
 To make an existing release available on another channel, use
@@ -128,14 +127,14 @@ promoting to `Beta`, and ultimately releasing on `Stable`.
 For the purposes of the lab, let's just promote the release straight through.
 
 ```
-replicated release promote 2 Beta --version 16.7.0 \
+replicated release promote 1 Beta --version 16.7.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK"
 ```
 
 and then
 
 ```
-replicated release promote 2 Stable --version 16.7.0 \
+replicated release promote 1 Stable --version 16.7.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK"
 ```
 
@@ -143,6 +142,5 @@ You can see they were promoted by listing your releases again:
 
 ```
 SEQUENCE    CREATED                 EDITED                  ACTIVE_CHANNELS
-2           2023-06-08T00:23:40Z    0001-01-01T00:00:00Z    Stable,Beta,Unstable
-1           2023-06-08T00:19:43Z    0001-01-01T00:00:00Z
+1           2023-06-08T00:23:40Z    0001-01-01T00:00:00Z    Stable,Beta,Unstable
 ```

--- a/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
+++ b/instruqt/distributing-with-replicated/03-creating-a-release/assignment.md
@@ -138,7 +138,8 @@ replicated release promote 1 Stable --version 16.7.0 \
   --release-notes "Prepares for distribution with Replicated by incorporating the Replicated SDK"
 ```
 
-You can see they were promoted by listing your releases again:
+You can see they were promoted by listing your releases again. You should see
+similar output to the following:
 
 ```
 SEQUENCE    CREATED                 EDITED                  ACTIVE_CHANNELS

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -24,4 +24,4 @@ lab_config:
   overlay: false
   width: 33
   position: right
-checksum: "9254975006048077381"
+checksum: "11216567145031576492"


### PR DESCRIPTION
TL;DR
-----

Update release promotion instructions to use match existing sequence
numbers

Details
-------

Up until recently every Builders experience lab started with an empty
release of the application. This was kind of accidental: the lab
automation creates a release for the application, and those labs didn't
really need one. It worked out OK since the Vendor Portal allowed the
empty release and the lab instructions took the release into account.

This all changed when the Vendor portal team tighten the constraints on
releases, at least for Builders experience applications. The empty
release doesn't have a Helm chart in it. So no release is created and
the automation silently failed. The labs continued to work since the
release is created near the end and everything the labs need was in
place.

What did fail was copy/paste of the lab instructions. The instructions
assumed the empty release was there and once it wasn't pain ensued.
Learners had to copy, paste, and update or just got frustrated with
failing commands. To provide them a remedy, this change updates the
instructions to account for the empty release not existing. This is how
the labs were intended to run from the beginning, starting with zero
releases.

Of course this mostly fixes the symptom and is only a short term fix.
The longer term fix is twofold:

1. Correct the automation to not create a release if the vendor track
   setup doesn't provide a directory for it.
2. Allow the track author to specify a version number for the release
   when one is created.

The latter may not be an obvious requirement, but it's needed since the
current release creation hardcodes the version number `0.1.0`. That
won't work with Builders releases since the application version needs to
match the chart version and not all charts being released to support a
lab will be version `0.1.0`.  I discovered this latter part when trying
a quick fix of dropping the Harbor Helm chart into a directory and
specifying that directory to create the release.
