### PR TITLE
Corrects application name for EC lab vendor portal metadata

### DIFF
--- a/instruqt/delivering-as-an-appliance/track.yml
+++ b/instruqt/delivering-as-an-appliance/track.yml
@@ -43,7 +43,8 @@ lab_config:
   feedback_recap_enabled: true
   feedback_tab_enabled: false
   loadingMessages: true
-  lab_v2: false
   override_challenge_layout: false
   hideStopButton: false
-checksum: "10301205870831719923"
+  default_layout: AssignmentRight
+  default_layout_sidebar_size: 25
+checksum: "9911192172985670499"

--- a/instruqt/delivering-as-an-appliance/vendor/vendor.json
+++ b/instruqt/delivering-as-an-appliance/vendor/vendor.json
@@ -1,5 +1,5 @@
 {
-    "name": "SlackerNews",
+    "name": "Slackernews",
     "slug": "slackernews",
     "customer": "Omozan",
     "yaml_dir": "",


### PR DESCRIPTION
TL;DR
-----

Updates metadata for Vendor Portal setup in "Delivering..." lab

Details
-------

Provides a quick fix to a bug that was preventing the "Delivering Your
Application as a Kubernetes Appliance" lab from starting. The track setup was
failing because the vendor metadata used the name "SlackerNews" and the
function to the app slug defaults to "Slackernews".

The natural fix would have been to avoid the default, but there seems to be a
call to `get_app_slug` embedded elsewhere that would blank the value again. I
don't love the inconsistency, but this approach gets the lab running again.

TODO
----

Dig into this problenm more deeply to determine if we should either simplify
the Vendor Portal setup or track down the code that blanks the app slug.
