### PR TITLE
Adapts "Delivering..." to Embedded Cluster chagnes

### DIFF
--- a/instruqt/delivering-as-an-appliance/05-downloading-and-installing/solve-node
+++ b/instruqt/delivering-as-an-appliance/05-downloading-and-installing/solve-node
@@ -49,13 +49,6 @@ curl -f https://replicated.app/embedded/${app_slug}/stable \
 
 echo "The install command takes a long time and Instruqt can't handle its output..."
 
-./${app_slug} install --license license.yaml --no-prompt --skip-host-preflights > /dev/null
-
-export KUBECONFIG="/var/lib/k0s/pki/admin.conf"
-export PATH="/var/lib/embedded-cluster/bin:${PATH}"
-
-# set the admin console password
-echo "Setting the admin console password... $(agent variable get ADMIN_CONSOLE_PASSWORD)"
-echo "$(agent variable get ADMIN_CONSOLE_PASSWORD)" | kubectl kots reset-password --namespace kotsadm 
+./${app_slug} install --license license.yaml --no-prompt --skip-host-preflights --admin-console-password $(agent variable get ADMIN_CONSOLE_PASSWORD) > /dev/null
 
 exit 0

--- a/instruqt/delivering-as-an-appliance/06-completing-the-install/check-node
+++ b/instruqt/delivering-as-an-appliance/06-completing-the-install/check-node
@@ -4,9 +4,10 @@
 set -euxo pipefail
 source /etc/profile.d/header.sh
 
+ec_install_dir="/var/lib/embedded-cluster"
 app_slug=$(get_app_slug)
-export KUBECONFIG="/var/lib/k0s/pki/admin.conf"
-export PATH="/var/lib/embedded-cluster/bin:${PATH}"
+export KUBECONFIG="${ec_install_dir}/k0s/pki/admin.conf"
+export PATH="${ec_install_dir}/bin:${PATH}"
 
 result=0
 status=$(kubectl get deploy --namespace kotsadm slackernews --output json | jq -r '.status.conditions[] | select( .type == "Available" ) | .status')

--- a/instruqt/delivering-as-an-appliance/06-completing-the-install/setup-node
+++ b/instruqt/delivering-as-an-appliance/06-completing-the-install/setup-node
@@ -17,8 +17,9 @@ fi
 
 # download the Replicated KOTS CLI, which plugs into the `kubectl` command
 # and provides a subcommend to reset the password for the admin console
-mkdir -p /var/lib/embedded-cluster/bin
-export REPL_INSTALL_PATH=/var/lib/embedded-cluster/bin
+ec_install_dir=/var/lib/embedded-cluster
+mkdir -p ${ec_install_dir}/bin
+export REPL_INSTALL_PATH=${ec_install_dir}/bin
 curl https://kots.io/install | bash
 
 agent variable set SLACKERNEWS_DOMAIN $(get_slackernews_domain)

--- a/instruqt/delivering-as-an-appliance/06-completing-the-install/solve-node
+++ b/instruqt/delivering-as-an-appliance/06-completing-the-install/solve-node
@@ -4,14 +4,16 @@
 set -euxo pipefail
 source /etc/profile.d/header.sh
 
+ec_install_dir="/var/lib/embedded-cluster"
+
 app_slug=$(get_app_slug)
 app_id=$(get_app_id)
 api_token=$(agent variable get REPLICATED_API_TOKEN)
 customer_id=$(agent variable get CUSTOMER_ID)
 license_id=$(agent variable get LICENSE_ID)
 
-export KUBECONFIG="/var/lib/k0s/pki/admin.conf"
-export PATH="/var/lib/embedded-cluster/bin:${PATH}"
+export KUBECONFIG="${ec_install_dir}/k0s/pki/admin.conf"
+export PATH="${ec_install_dir}/bin:${PATH}"
 
 # prepare values for installation
 cat <<CONFIG_VALUES > /tmp/config-values.yaml

--- a/instruqt/delivering-as-an-appliance/track.yml
+++ b/instruqt/delivering-as-an-appliance/track.yml
@@ -47,4 +47,4 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 25
-checksum: "9911192172985670499"
+checksum: "8888110905668754440"

--- a/instruqt/distributing-with-replicated/track.yml
+++ b/instruqt/distributing-with-replicated/track.yml
@@ -28,8 +28,7 @@ lab_config:
   feedback_recap_enabled: true
   feedback_tab_enabled: false
   loadingMessages: true
-  lab_v2: false
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 33
-checksum: "9648206013188099501"
+checksum: "2082361330332165496"

--- a/instruqt/meet-the-platform/01-accessing-the-platform/assignment.md
+++ b/instruqt/meet-the-platform/01-accessing-the-platform/assignment.md
@@ -30,7 +30,9 @@ you need to work with the Platform from the web, the command-line, and
 anywhere you can invoke its APIs.
 
 This lab will introduce you to the Replicated Platform through the Vendor
-Portal. After getting to know the Vendor Portal, you'll take the role of the
-customers and install [SlackerNews](https://slackernews.io), an application
+Portal. After getting to know the Vendor Portal, you'll take the role of a
+customer and install [SlackerNews](https://slackernews.io), an application
 distributed with Replicated. From there, we'll show you how you'll work with
 customers having a support issue, and how they'll install a fix.
+
+


### PR DESCRIPTION
TL;DR
-----

Updates the "Delivering..." lab for changes to Embedded Cluster

Details
-------

Restores the "Delivering Your Application as a Kubernetes Appliance" lab
to working order. The lab stopped working when changes to the embedded
cluster relocated the `admin.conf` file that a few scripts referenced as
their `KUBECONFIG`.

Also takes advantage of the new(ish) `--admin-console-password` flag to
set the Admin Console password in in the solve script for the fifth
challenge. The earlier script used KOTS to set the password, but
streamlining it to the expected approach feels a lot cleaner and
future-proof.
