### PR TITLE
Adjusts caching on the EC version to avoid errors

### DIFF
--- a/instruqt/delivering-as-an-appliance/03-collecting-configuration/setup-shell
+++ b/instruqt/delivering-as-an-appliance/03-collecting-configuration/setup-shell
@@ -31,7 +31,7 @@ spec:
         and the user who can administer it.
 
         Users that you specify under **Admin Users** will be able to access the
-        Slackernews adminstrative console at `/admin`, allowing them to manage
+        Slackernews adminstrative console at \`/admin\`, allowing them to manage
         content, users, and settings. Changes will take effect the next time
         they are active in the Slackernews application.
       items:
@@ -39,7 +39,7 @@ spec:
           title: Ingress Hostname
           help_text: >
             The domain name at which you'll access SlackerNews. Don't include
-            the `https://` or any path elements.
+            the \`https://\` or any path elements.
           type: text
           required: true
           validation:

--- a/instruqt/delivering-as-an-appliance/track.yml
+++ b/instruqt/delivering-as-an-appliance/track.yml
@@ -47,4 +47,4 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 25
-checksum: "8888110905668754440"
+checksum: "10811747556592817534"

--- a/libs/header.sh
+++ b/libs/header.sh
@@ -50,10 +50,10 @@ get_replicated_sdk_version () {
 
 get_embedded_cluster_version () {
   set +eu pipefail
-  replicated_sdk_version=$(agent variable get REPLICATED_SDK_VERSION)
+  embedded_cluster_version=$(agent variable get EMBEDDED_CLUSTER_VERSION)
 
   # if we don't already have a token, fetch one
-  if [[ -z "$replicated_sdk_version" ]]; then
+  if [[ -z "$empedded_cluster_version" ]]; then
     embedded_cluster_version=$(curl -s "https://api.github.com/repos/replicatedhq/embedded-cluster/releases/latest" | jq -r .tag_name)
   fi
 


### PR DESCRIPTION
TL;DR
-----

Updates the function for fetching the EC version to check the right
variable when catching

Details
-------

We were getting some download errors on the Embedded Cluster. It was
sporadic and there were a couple of options. The first was GitHub rate
limits, which may still be a factor. The second was that the version was
either not being fetched or being fetched incorrectly.

Investigating the second option, I realized that the code that checked
the runtime variable for the version was checking the wrong variable.
This change checks the right variable there. I'm not 100% sure this will
be a lasting fix to the issue, but it was a bug and it was in the right
area.

The code also updates the track checksum (since it changes with every
push) and fixes an error where the config help text had some variable
interpolation problems.
