### PR TITLE
Adapts EC lab for preflight and default updates

### DIFF
--- a/instruqt/delivering-as-an-appliance/01-specifying-the-cluster/assignment.md
+++ b/instruqt/delivering-as-an-appliance/01-specifying-the-cluster/assignment.md
@@ -19,6 +19,7 @@ tabs:
   hostname: shell
 difficulty: basic
 timelimit: 300
+enhanced_loading: null
 ---
 
 A virtual Kubernetes appliance consists of your application, a Kubernetes

--- a/instruqt/delivering-as-an-appliance/01-specifying-the-cluster/setup-shell
+++ b/instruqt/delivering-as-an-appliance/01-specifying-the-cluster/setup-shell
@@ -26,3 +26,4 @@ done
 mkdir -p ${HOME_DIR}/release
 chown replicant:replicant ${HOME_DIR}/release
 chmod 755 ${HOME_DIR}/release
+

--- a/instruqt/delivering-as-an-appliance/02-customize-for-your-app/assignment.md
+++ b/instruqt/delivering-as-an-appliance/02-customize-for-your-app/assignment.md
@@ -19,6 +19,7 @@ tabs:
   hostname: shell
 difficulty: basic
 timelimit: 300
+enhanced_loading: null
 ---
 
 The Kubernetes appliance installation is one of the first things

--- a/instruqt/delivering-as-an-appliance/03-collecting-configuration/assignment.md
+++ b/instruqt/delivering-as-an-appliance/03-collecting-configuration/assignment.md
@@ -22,6 +22,7 @@ tabs:
   hostname: shell
 difficulty: basic
 timelimit: 300
+enhanced_loading: null
 ---
 
 One of the benefits of building a Kubernetes appliance is providing a guided

--- a/instruqt/delivering-as-an-appliance/04-using-the-configuration/assignment.md
+++ b/instruqt/delivering-as-an-appliance/04-using-the-configuration/assignment.md
@@ -20,6 +20,7 @@ tabs:
   hostname: shell
 difficulty: basic
 timelimit: 300
+enhanced_loading: null
 ---
 
 The configuration screen we built looks great, guides the customer through

--- a/instruqt/delivering-as-an-appliance/05-downloading-and-installing/assignment.md
+++ b/instruqt/delivering-as-an-appliance/05-downloading-and-installing/assignment.md
@@ -21,6 +21,7 @@ tabs:
   new_window: true
 difficulty: basic
 timelimit: 1200
+enhanced_loading: null
 ---
 
 Now that we've prepared SlackerNews for an Embedded Cluster installation,

--- a/instruqt/delivering-as-an-appliance/05-downloading-and-installing/setup-node
+++ b/instruqt/delivering-as-an-appliance/05-downloading-and-installing/setup-node
@@ -25,4 +25,6 @@ agent variable set ADMIN_EMAIL "${INSTRUQT_PARTICIPANT_ID}@nitflex.tv"
 agent variable set CUSTOMER_ID $(get_customer_id Nitflex)
 agent variable set LICENSE_ID $(get_license_id Nitflex)
 
+echo "export SKIP_HOST_PREFLIGHTS=true" >> /root/.bashrc
+
 exit 0

--- a/instruqt/delivering-as-an-appliance/05-downloading-and-installing/setup-node
+++ b/instruqt/delivering-as-an-appliance/05-downloading-and-installing/setup-node
@@ -18,8 +18,6 @@ fi
 # download the Replicated KOTS CLI, which plugs into the `kubectl` command
 # and provides a subcommend to reset the password for the admin console
 mkdir -p /var/lib/embedded-cluster/bin
-export REPL_INSTALL_PATH=/var/lib/embedded-cluster/bin
-curl https://kots.io/install | bash
 
 agent variable set ADMIN_CONSOLE_PASSWORD "$(get_admin_console_password)"
 agent variable set SLACKERNEWS_DOMAIN get_slackernews_domain

--- a/instruqt/delivering-as-an-appliance/05-downloading-and-installing/solve-node
+++ b/instruqt/delivering-as-an-appliance/05-downloading-and-installing/solve-node
@@ -49,6 +49,6 @@ curl -f https://replicated.app/embedded/${app_slug}/stable \
 
 echo "The install command takes a long time and Instruqt can't handle its output..."
 
-./${app_slug} install --license license.yaml --no-prompt --skip-host-preflights --admin-console-password $(agent variable get ADMIN_CONSOLE_PASSWORD) > /dev/null
+./${app_slug} install --license license.yaml --no-prompt --admin-console-password $(agent variable get ADMIN_CONSOLE_PASSWORD) > /dev/null
 
 exit 0

--- a/instruqt/delivering-as-an-appliance/06-completing-the-install/assignment.md
+++ b/instruqt/delivering-as-an-appliance/06-completing-the-install/assignment.md
@@ -22,6 +22,7 @@ tabs:
   new_window: true
 difficulty: basic
 timelimit: 1200
+enhanced_loading: null
 ---
 
 We're part way through the installation of SlackerNews as a Kubernetes

--- a/instruqt/delivering-as-an-appliance/track.yml
+++ b/instruqt/delivering-as-an-appliance/track.yml
@@ -36,9 +36,6 @@ developers:
 idle_timeout: 700
 timelimit: 2400
 lab_config:
-  overlay: false
-  width: 25
-  position: right
   sidebar_enabled: true
   feedback_recap_enabled: true
   feedback_tab_enabled: false
@@ -47,4 +44,5 @@ lab_config:
   hideStopButton: false
   default_layout: AssignmentRight
   default_layout_sidebar_size: 25
-checksum: "10811747556592817534"
+checksum: "1997671224954465538"
+enhanced_loading: false

--- a/instruqt/delivering-as-an-appliance/track_scripts/setup-shell
+++ b/instruqt/delivering-as-an-appliance/track_scripts/setup-shell
@@ -444,7 +444,7 @@ rm ${HOME_DIR}/release/slackernews-0.4.1.tgz
 customer_email="${INSTRUQT_PARTICIPANT_ID}@nitflex.tv"
 
 # create the new customer and keep track of the ID
-customer_id=$(replicated customer create --name "Nitflex" --email ${customer_email} --channel Stable --default-channel Stable --expires-in 1460h --type trial --kots-install=true --embedded-cluster-download=false --output json --app ${app_slug} --token ${api_token} | jq -r .id)
+customer_id=$(replicated customer create --name "Nitflex" --email ${customer_email} --channel Stable --default-channel Stable --expires-in 1460h --type trial --kots-install=false --output json --app ${app_slug} --token ${api_token} | jq -r .id)
 
 # this section is just to match the deployment history from the "Protecting..." lab
 yq -i '.version = "0.5.0"' ${HOME_DIR}/slackernews/Chart.yaml

--- a/instruqt/delivering-as-an-appliance/track_scripts/setup-shell
+++ b/instruqt/delivering-as-an-appliance/track_scripts/setup-shell
@@ -444,7 +444,7 @@ rm ${HOME_DIR}/release/slackernews-0.4.1.tgz
 customer_email="${INSTRUQT_PARTICIPANT_ID}@nitflex.tv"
 
 # create the new customer and keep track of the ID
-customer_id=$(replicated customer create --name "Nitflex" --email ${customer_email} --channel Stable --default-channel Stable --expires-in 1460h --type trial --kots-install=false --output json --app ${app_slug} --token ${api_token} | jq -r .id)
+customer_id=$(replicated customer create --name "Nitflex" --email ${customer_email} --channel Stable --default-channel Stable --expires-in 1460h --type trial --kots-install=true --embedded-cluster-download=false --output json --app ${app_slug} --token ${api_token} | jq -r .id)
 
 # this section is just to match the deployment history from the "Protecting..." lab
 yq -i '.version = "0.5.0"' ${HOME_DIR}/slackernews/Chart.yaml


### PR DESCRIPTION
TL;DR
-----

Corrects the Embedded Cluster lab to address changes in Embedded Cluster
preflights and Vendor Portal defaults


Details
--------

Skip host preflights by default in the Embedded Cluster lab. This is *required* because of an incompatibility between the check for a wildcard DNS record and the Instruqt infrastructure. Instruqt has a wildcard DNS entry that causes the preflight to fail, and we need to have a lab for Embedded Cluster. Since I didn't want to teach the bad habit of ignoring preflight failures, I had to [add an environment variable to the Embedded Cluster CLI](replicatedhq/embedded-cluster#2364) and use it to skip the preflights.

While I was testing the change, I realized we had issues with inconsistencies in the defaults in the `replicated` CLI that meant some of our customer creation steps in lab setup were failing. This change addresses those issues.

Also removes the KOTS CLI installation process that isn't needed any longer. 

